### PR TITLE
Ajout d'un zeste de précision dans l'horaire d'envoi du SMS

### DIFF
--- a/controllers/internalConsole.php
+++ b/controllers/internalConsole.php
@@ -130,6 +130,10 @@
 				{
 					echo "	Envoi d'un SMS au " . $number . "\n";
 					//On ajoute le SMS aux SMS envoyés
+					//Pour plus de précision, on remet la date à jour en réinstanciant l'objet DateTime (et on reformatte la date, bien entendu)
+					$now = new DateTime();
+					$now = $now->format('Y-m-d H:i:s');
+					//On peut maintenant ajouter le SMS
 					$db->createSended($now, $number, $scheduled['content']);
 					$id_sended = $db->lastId();
 					


### PR DESCRIPTION
La date actuelle est maintenant recalculée juste avant l'ajout de ___chaque SMS___ dans la
base de données.
Lisez mon commentaire ci-dessous pour en savoir plus sur l'effort d'augmenter la
précision dans le timing d'envoi et les différentes façons de s'y prendre.