### PR TITLE
Correct error on php 7.0

### DIFF
--- a/console.php
+++ b/console.php
@@ -51,5 +51,5 @@
 		exit(2); //Sorti avec erreur
 	}
 
-	$controller->$options['c'](); //On appel la fonction
+	$controller->{$options['c']}(); //On appel la fonction
 


### PR DESCRIPTION
Line 54 returns array to string conversion on PHP 7. This does not allow the command to be executed as the command is understood as an array. Braces are correcting this problem and should be compatible with older versions of PHP.