### PR TITLE
Fix errors when creating and receiving SMS

### DIFF
--- a/controllers/internalConsole.php
+++ b/controllers/internalConsole.php
@@ -204,7 +204,7 @@
 				foreach (scandir(PWD_RECEIVEDS) as $dir)
 				{
 					//Si le fichier est un fichier système, on passe à l'itération suivante
-					if ($dir == '.' || $dir == '..' || $dir == '.tokeep')
+					if ($dir == '.' || $dir == '..' || $dir == '.tokeep' || $dir == '.to-keep')
 					{
 						continue;
 					}				

--- a/controllers/scheduleds.php
+++ b/controllers/scheduleds.php
@@ -180,7 +180,7 @@
 				return false;
 			}		
 
-			if (!$db->insertIntoTable('scheduleds', ['at' => $date, 'content' => $content, 'progress' => false]))
+			if (!$db->insertIntoTable('scheduleds', ['at' => $date, 'content' => $content, 'progress' => 0]))
 			{
 				if (!$api)
 				{


### PR DESCRIPTION
I fixed 2 errors that happened on my Raspberry Pi installation:
* When creating a new SMS, the INSERT request didn't work because of the progress value set to `false`. I don't know why but changing to `0` fix the issue.
* When receiving a new SMS, the file `.to-keep` was not ignored in the directory

PS: Please update the .tar.gz on the [website](https://raspisms.raspberry-pi.fr/download/) after merging this pull request.