### PR TITLE
Make sure Gammu speaks english

### DIFF
--- a/adapters/GammuAdapter.php
+++ b/adapters/GammuAdapter.php
@@ -188,6 +188,7 @@ namespace adapters;
             }
 
             $command_parts = [
+                'LC_ALL=C',
                 'gammu',
                 '--config',
                 escapeshellarg($this->data['config_file']),
@@ -339,6 +340,7 @@ namespace adapters;
             }
 
             $command_parts = [
+                'LC_ALL=C',
                 'gammu',
                 '--config',
                 escapeshellarg($this->data['config_file']),
@@ -351,6 +353,7 @@ namespace adapters;
 
             //Check security status
             $command_parts = [
+                'LC_ALL=C',
                 'gammu',
                 '--config',
                 escapeshellarg($this->data['config_file']),


### PR DESCRIPTION
Gammu returns localized messages whereas GammuAdapter searches for string "nothing". Force Gammu to return english messages so word searches will work properly. This fixes #172