### PR TITLE
Don't bother to check SIM security status on successful unlock

### DIFF
--- a/adapters/GammuAdapter.php
+++ b/adapters/GammuAdapter.php
@@ -337,7 +337,9 @@ namespace adapters;
             {
                 return true;
             }
-
+            
+            // The command returns 123 on failed execution (even if SIM is already unlocked), and returns 0 if unlock was successful
+            // We can directly return true if command was succesful
             $command_parts = [
                 'gammu',
                 '--config',
@@ -348,8 +350,13 @@ namespace adapters;
             ];
 
             $result = $this->exec_command($command_parts);
+            if (0 === $result['return'])
+            {
+                return true;
+            }
 
             //Check security status
+            // The command returns 0 regardless of the SIM security state
             $command_parts = [
                 'gammu',
                 '--config',


### PR DESCRIPTION
When unlocking SIM via Gammu, we don't need to additional check for securitystatus if unlocking was sucessful.
Also, it's nice to document gammu output codes so we understand the logic used in the adapter.