### PR TITLE
Make sure Gammu always sends as UTF-8 format

### DIFF
--- a/adapters/GammuAdapter.php
+++ b/adapters/GammuAdapter.php
@@ -195,7 +195,7 @@ namespace adapters;
                 'sendsms',
                 'TEXT',
                 escapeshellarg($destination),
-                '-text',
+                '-textutf8',
                 escapeshellarg($text),
                 '-validity',
                 'MAX',


### PR DESCRIPTION
I'm sorry, I didn't test enough #191 
As a matter of fact, adding `LC_ALL=C` thereby forcing gammu to speak english works well, but will fail to make accent characters.

Strangely enough, using `-textutf8` instead of `-text` works, regardless if gammu config file `gammucoding = utf8` option was used.


This PR fixes that behavior forcing gammu to send all texts as UTF-8.
Since it's 2022, we're pretty safe no-one is using ISO8859 or so I guess ,;)

