### PR TITLE
Make HTTPS proxies work

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,3 +3,7 @@ RewriteRule ^assets - [L]
 RewriteRule ^.well-known - [L]
 RewriteRule ^data/public/ - [L]
 RewriteRule . index.php
+
+<IfModule headers_module>
+    Header always set Content-Security-Policy "upgrade-insecure-requests;"
+</ifModule>


### PR DESCRIPTION
Running RaspiSMS behind HaProxy or equivalent needs a bit of tuning.
Most MVC frameworks understand X-forwared-proto header, so here's the simple implementation for descartes.